### PR TITLE
Fixed issue with running xarjs on a .safariextension outside of the working dir

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ function generateArchive(archivePath: string, files: string[], opts: GenerateOpt
   let writer = new FileWriter(archivePath);
   let archive = new XarArchive();
   for (let file of files) {
-    archive.addFile(walk(file));
+    archive.addFile(walk(file, true));
   }
   if (opts.privateKey) {
       let privateKey = fs.readFileSync(opts.privateKey, 'utf-8');

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,12 +11,12 @@ FileType,
 /** Process a file or directory tree and create a XarFile representing
  * its contents.
  */
-export function walk(filePath: string): XarFile {
+export function walk(filePath: string, isTopLevel?: boolean): XarFile {
   let fileInfo = fs.statSync(filePath);
   let children: XarFile[];
   if (fileInfo.isDirectory()) {
     return <XarDirectory>{
-      name: path.basename(filePath),
+      name: isTopLevel ? filePath : path.basename(filePath),
       type: FileType.Directory,
       children: fs.readdirSync(filePath).map(basename => walk(path.join(filePath, basename)))
     };


### PR DESCRIPTION
Thanks again for the great tool! This is really helpful for automating our build process.

We ran into an issue when trying to build an extension outside of the current working directory. For example:

```
xarjs test.safariextz --cert cert.pem --cert apple-root.pem --cert apple-intermediate.pem --private-key privatekey.pem \
  ./other-directory/test.safariextension
```

Expected result: successful build
Actual result:

```
/Users/peterxu/Documents/Code/test/build/safari/../../client/extensions/safari.safariextension
fs.js:549
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open 'safari.safariextension/.DS_Store'
    at Error (native)
    at Object.fs.openSync (fs.js:549:18)
    at new FileReader (/Users/peterxu/Documents/Code/test/node_modules/xar-js/build/src/io.js:14:22)
    at /Users/peterxu/Documents/Code/test/node_modules/xar-js/build/src/cli.js:23:55
    at /Users/peterxu/Documents/Code/test/node_modules/xar-js/build/src/lib.js:296:30
    at Array.forEach (native)
    at XarArchive.generate (/Users/peterxu/Documents/Code/test/node_modules/xar-js/build/src/lib.js:292:18)
    at generateArchive (/Users/peterxu/Documents/Code/test/node_modules/xar-js/build/src/cli.js:23:13)
    at Command.<anonymous> (/Users/peterxu/Documents/Code/test/node_modules/xar-js/build/src/cli.js:35:5)
    at Command.listener (/Users/peterxu/Documents/Code/test/node_modules/xar-js/node_modules/commander/index.js:301:8)
```
