### PR TITLE
Fix signing when input private key length is not 2048 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- Calculate signature length by signing dummy data, rather than assuming
+  a fixed size. Fixes signing when private key length is not 2048 bits.
+
+  See https://github.com/robertknight/xar-js/issues/9
+
 - Fixed an issue where `xarjs create` would fail to read input files
   outside of the current directory.
 


### PR DESCRIPTION
The output signature size depends upon the input key size, so will be
512 bytes rather than 256 if a 4096-bit key is used for example.

Calculate the signature size by signing dummy data rather than assuming
a fixed size.

Fixes #9
